### PR TITLE
Disable zoom on the tapboards

### DIFF
--- a/emf/templates/emf/tapboard.html
+++ b/emf/templates/emf/tapboard.html
@@ -4,7 +4,7 @@
   <head>
     <title>{% block title %}EMF Tap Board{% endblock %}</title>
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <link rel="manifest" href="{% static "emf/tapboard-manifest.json" %}">
     <link rel="STYLESHEET" type="text/css" href="{% static "emf/css/tapboard.css" %}">
     <script>


### PR DESCRIPTION
It happens accidentally, and breaks the purpose of the boards.